### PR TITLE
Fix: Use correct support set (main_support_dataset) for confusion matrix

### DIFF
--- a/ass1_skeleton.ipynb
+++ b/ass1_skeleton.ipynb
@@ -1561,7 +1561,7 @@
    "source": [
     "# create a confusion matrix with the first 10 classes over main_test_dataset and main_support_dataset\n",
     "test_loader_main_test = DataLoader(main_test_dataset, batch_size=1, shuffle=False)\n",
-    "support_loader_main_train = DataLoader(train_dataset, batch_size=1, shuffle=False)\n",
+    "support_loader_main_support = DataLoader(main_support_dataset, batch_size=1, shuffle=False)\n",
     "\n",
     "# Extract embeddings\n",
     "test_embeddings_main_test = []\n",
@@ -1575,7 +1575,7 @@
     "\n",
     "support_embeddings_main_train = []\n",
     "support_labels_main_train = []\n",
-    "for image, label in support_loader_main_train:\n",
+    "for image, label in support_loader_main_support:\n",
     "    if label[0] in range(10):\n",
     "        image = image.to(device)\n",
     "        with torch.no_grad():\n",


### PR DESCRIPTION
Assignment: "Create a confusion matrix using:
• Support set: the first 10 classes4 from the main classes support dataset.
• Test set: the first 10 classes from the main classes test dataset."